### PR TITLE
Updated README to clear ambiguity in verbiage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Downloads](https://img.shields.io/npm/dm/napajs.svg)](https://www.npmjs.com/package/napajs)
 
 # Napa.js
-Napa.js is a multi-threaded JavaScript runtime built on [V8](https://github.com/v8/v8), which was originally designed to develop highly iterative services with non-compromised performance in Bing. As it evolves, we find it useful to complement [Node.js](https://nodejs.org) in CPU-bound tasks, with the capability of executing JavaScript in multiple V8 isolates and communicating between them. Napa.js is exposed as a Node.js module, while it can also be embedded in a host process without Node.js dependency.
+Napa.js is a multi-threaded JavaScript runtime built on [V8](https://github.com/v8/v8). Napa was originally designed to develop highly iterative services with non-compromised performance in Bing. As it evolved, we found it useful to complement [Node.js](https://nodejs.org) in CPU-bound tasks by enabling JavaScript execution in multiple V8 isolates and administering communication among them. Even though Napa.js is a Node.js module, it can also be embedded in a host process without a Node.js dependency.
 
 ## Supported OS and Compilers
 Napa.js requires C++ compiler that supports [C++14](https://en.wikipedia.org/wiki/C%2B%2B14), currently we have tested following OS/compiler combinations: 


### PR DESCRIPTION
Addressed certain grammatical elements in the README file that created ambiguity in interpretation. 
 - "which" was qualifying V8 engine than that original intent to qualify Napa project
 - changed tenses to clarify the intended historical context