### PR TITLE
remove third-party dir in npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 bin
 build
 examples
-third-party
 
 # Exclude TypeScript source files.
 benchmark/**/*.ts


### PR DESCRIPTION
remove third-party dir in npmignore for building during npm install when pre-build retriving failed