### PR TITLE
Update comments in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
         - g++-5
     env:
     - COMPILER_OVERRIDE="CXX=g++-5 CC=gcc-5"
-  # Node LTS (6.x)      OS X (Yosemite)     LLVM 6.1
+  # Node LTS (6.x)      OS X (Yosemite)     AppleClang 6.1
   - os: osx
     node_js: '6'
     osx_image: xcode6.4
@@ -53,7 +53,7 @@ matrix:
         - g++-6
     env:
     - COMPILER_OVERRIDE="CXX=g++-6 CC=gcc-6"
-  # Node LTS (8.x)      OS X (El Capitan)   LLVM 7.3
+  # Node LTS (8.x)      OS X (El Capitan)   AppleClang 7.3
   - os: osx
     node_js: '8'
     osx_image: xcode7.3


### PR DESCRIPTION
Fix compiler name in OS X. (AppleClang version is not LLVM version)