### PR TITLE
Fix RPATH for shared library

### DIFF
--- a/node/CMakeLists.txt
+++ b/node/CMakeLists.txt
@@ -18,6 +18,12 @@ add_library(${TARGET_NAME} SHARED ${SOURCE_FILES})
 
 set_target_properties(${TARGET_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
 
+# Rpath definitions
+set_target_properties(${TARGET_NAME} PROPERTIES
+    BUILD_WITH_INSTALL_RPATH TRUE
+    INSTALL_RPATH "$ORIGIN/"
+    INSTALL_RPATH_USE_LINK_PATH FALSE)
+
 # Include directories
 target_include_directories(${TARGET_NAME} PRIVATE
     ${CMAKE_JS_INC}

--- a/node/CMakeLists.txt
+++ b/node/CMakeLists.txt
@@ -19,9 +19,15 @@ add_library(${TARGET_NAME} SHARED ${SOURCE_FILES})
 set_target_properties(${TARGET_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
 
 # Rpath definitions
+
+if (APPLE)
+    set_target_properties(${TARGET_NAME} PROPERTIES INSTALL_RPATH "@loader_path")
+else ()
+    set_target_properties(${TARGET_NAME} PROPERTIES INSTALL_RPATH "$ORIGIN/")
+endif()
+
 set_target_properties(${TARGET_NAME} PROPERTIES
     BUILD_WITH_INSTALL_RPATH TRUE
-    INSTALL_RPATH "$ORIGIN/"
     INSTALL_RPATH_USE_LINK_PATH FALSE)
 
 # Include directories


### PR DESCRIPTION
This change should resolve issue #80 .

- Update rpath to '$ORIGIN/' on Linux.
- Update rpath to '@loader_path' on Mac OS.