### PR TITLE
Update Zone API Documentation Grammar

### DIFF
--- a/docs/api/zone.md
+++ b/docs/api/zone.md
@@ -32,9 +32,9 @@ Zone is a key concept of napajs that exposes multi-thread capabilities in JavaSc
 Please note that it's not the same `zone` concept of a context object for async calls in [Dart](https://www.dartlang.org/articles/libraries/zones), or [Augular](https://github.com/angular/zone.js), or a proposal in [TC39](https://github.com/domenic/zones).
 
 ### <a name="worker-vs-zone"></a> Multiple workers vs. Multiple zones
-Zone consists of one or multiple JavaScript threads, we name each thread `worker`. Workers within a zone are symmetric, which means execute on any worker from the zone should return the same result, and the internal state of every worker should be the same from long running point of view. 
+Zone consists of one or multiple JavaScript threads, we name each thread `worker`. Workers within a zone are symmetric, which means code executed on any worker from the zone should return the same result, and the internal state of every worker should be the same from a long-running point of view. 
  
-Multiple zones can co-exist in the same process, with each loading different code, bearing different states or applying different policies, like heap size, etc. The purpose of having multiple zone is to allow multiple roles of a complex work, each role loads the minimum resource for its own usage.
+Multiple zones can co-exist in the same process, with each loading different code, bearing different states or applying different policies, like heap size, etc. The purpose of having multiple zone is to allow multiple roles for complex work, each role loads the minimum resources for its own usage.
  
 ### <a name="zone-types"></a> Zone types
 There are two types of zone:
@@ -43,7 +43,7 @@ There are two types of zone:
 
 ### <a name="zone-operations"><a> Zone operations 
 There are two operations, designed to reinforce the symmetry of workers within a zone:
- 1) **Broadcast** - run code that changes worker state on all workers, returning a promise for pending operation. Through the promise, we can only know if operation succeed or failed. Usually we use `broadcast` to bootstrap application, pre-cache objects, or change application settings.
+ 1) **Broadcast** - run code that changes worker state on all workers, returning a promise for the pending operation. Through the promise, we can only know if the operation succeed or failed. Usually we use `broadcast` to bootstrap the application, pre-cache objects, or change application settings.
  2) **Execute** - run code that doesn't change worker state on an arbitrary worker, returning a promise of getting the result. Execute is designed for doing the real work.
 
  Zone operations are on a basis of first-come-first-serve, while `broadcast` takes higher priority over `execute`.
@@ -72,7 +72,7 @@ Example:
 var zone = napa.zone.get('zone1');
 ```
 ### <a name="current"></a>current: Zone
-It returns a reference of the zone of current running isolate. If it's under node, it returns the [node zone](#node-zone).
+It returns a reference of the zone of the currently running isolate. If it's under node, it returns the [node zone](#node-zone).
 
 Example: Get current zone.
 ```js
@@ -86,7 +86,7 @@ Example:
 var zone = napa.zone.node;
 ```
 ## <a name="zone-settings"></a> Interface `ZoneSettings`
-Settings for zones, which will  be specified during creation of zones. If not specified, [DEFAULT_SETTINGS](#default-settings) will be used.
+Settings for zones, which will be specified during the creation of zones. If not specified, [DEFAULT_SETTINGS](#default-settings) will be used.
 
 ### <a name="zone-settings-workers"></a>settings.workers: number
 Number of workers in the zone.
@@ -99,14 +99,14 @@ Default settings for creating zones.
 }
 ```
 ## <a name="zone"></a> Interface `Zone`
-Zone is the basic concept to execute JavaScript and apply policies in Napa. You can find its definition in [Introduction](#intro). Through Zone API, developers can broadcast JavaScript code on all workers, or execute a function on one of them. When you program against a zone, it is the best practice to ensure all workers within a zone are symmetrical to each other, that you should not assume a worker may maintain its own states.
+Zone is the basic concept to execute JavaScript and apply policies in Napa. You can find its definition in [Introduction](#intro). Through the Zone API, developers can broadcast JavaScript code on all workers, or execute a function on one of them. When you program against a zone, it is the best practice to ensure all workers within a zone are symmetrical to each other, that is, you should not assume a worker may maintain its own states.
 
-The two major set of APIs are [`broadcast`](#broadcast-code) and [`execute`](#execute-by-name), which are asynchronous operations with a few variations on their inputs.
+The two major sets of APIs are [`broadcast`](#broadcast-code) and [`execute`](#execute-by-name), which are asynchronous operations with a few variations on their inputs.
 ### <a name="zone-id"></a> zone.id: string
 It gets the id of the zone.
 
 ### <a name="broadcast-code"></a> zone.broadcast(code: string): Promise\<void\>
-It asynchronously broadcasts a snippet of JavaScript code in a string to all workers, which returns a Promise of void. If any of the workers failed to execute the code, promise will be rejected with an error message.
+It asynchronously broadcasts a snippet of JavaScript code in a string to all workers, which returns a Promise of void. If any of the workers failed to execute the code, the promise will be rejected with an error message.
 
 Example:
 
@@ -122,7 +122,7 @@ zone.broadcast('var state = 0;')
     });
 ```
 ### <a name="broadcast-function"></a> zone.broadcast(function: (...args: any[]) => void, args?: any[]): Promise\<void\>
-It asynchronously broadcasts an anonymous function with its arguments to all workers, which returns a Promise of void. If any of the workers failed to execute the code, promise will be rejected with an error message.
+It asynchronously broadcasts an anonymous function with its arguments to all workers, which returns a Promise of void. If any of the workers failed to execute the code, the promise will be rejected with an error message.
 
 *Please note that Napa doesn't support closure in 'function' during broadcast.
 
@@ -140,7 +140,7 @@ zone.broadcast((state) => {
     });
 ```
 ### <a name="execute-by-name"></a> zone.execute(moduleName: string, functionName: string, args?: any[], options?: CallOptions): Promise\<any\>
-Execute a function asynchronously on arbitrary worker via module name and function name. Arguments can be of any JavaScript type that is [transportable](transport.md#transportable-types). It returns a Promise of [`Result`](#result). If error happens, either bad code, user exception, or timeout is reached, promise will be rejected.
+Execute a function asynchronously on an arbitrary worker via module name and function name. Arguments can be of any JavaScript type that is [transportable](transport.md#transportable-types). It returns a Promise of [`Result`](#result). If an error happens, either bad code, user exception, or timeout is reached, the promise will be rejected.
 
 Example: Execute function 'bar' in module 'foo', with arguments [1, 'hello', { field1: 1 }]. 300ms timeout is applied.
 ```js
@@ -160,12 +160,12 @@ zone.execute(
 
 ### <a name="execute-anonymous-function"></a> zone.execute(function: (...args: any[]) => any, args?: any[], options?: CallOptions): Promise\<any\>
 
-Execute a function object asynchronously on arbitrary worker. Arguments can be of any JavaScript type that is [transportable](transport.md#transportable-types). It returns a Promise of [`Result`](#result). If error happens, either bad code, user exception, or timeout is reached, promise will be rejected.
+Execute a function object asynchronously on an arbitrary worker. Arguments can be of any JavaScript type that is [transportable](transport.md#transportable-types). It returns a Promise of [`Result`](#result). If an error happens, either bad code, user exception, or timeout is reached, promise will be rejected.
 
 Here are a few restricitions on executing a function object:
 
 - The function object cannot access variables from closure
-- Unless the function object has `origin` property, it will use current file as `origin`, which will be used to set `__filename` and `__dirname`. (See [transporting functions](./transport.md#transporting-functions))
+- Unless the function object has an `origin` property, it will use the current file as `origin`, which will be used to set `__filename` and `__dirname`. (See [transporting functions](./transport.md#transporting-functions))
 
 Example:
 ```js
@@ -195,16 +195,16 @@ Output:
 /usr/file1.js
 ```
 ## <a name="call-options"></a> Interface `CallOptions`
-Interface for options to call function in `zone.execute`.
+Interface for options to call functions in `zone.execute`.
 
 ### <a name="call-options-timeout"></a> options.timeout: number
 Timeout in milliseconds. Default value 0 indicates no timeout.
 
 ## <a name="result"></a> Interface `Result`
-Interface to access return value of [`execute`](#execute-by-name).
+Interface to access the return value of [`execute`](#execute-by-name).
 
 ### <a name="result-value"></a>result.value: any
-JavaScript value returned from function which is invoked from zone.execute/executeSync. Napa marshall/unmarshall [transportable values](transport.md#transportable-types) between different workers (V8 isolates). Unmarshalling will happen when the first `result.value` is queried.
+JavaScript value returned from the function which is invoked from zone.execute/executeSync. Napa marshalls/unmarshalls [transportable values](transport.md#transportable-types) between different workers (V8 isolates). Unmarshalling will happen when the first `result.value` is queried.
 
 Example:
 ```js
@@ -212,7 +212,7 @@ var value = result.value;
 ```
 
 ### <a name="result-payload"></a> result.payload: string
-Marshalled payload (in JSON) from returned value. This field is for users that want to pass result through to its caller, where unmarshalled value is not required.  
+Marshalled payload (in JSON) from the returned value. This field is for users that want to pass results through to its caller, where the unmarshalled value is not required.  
 
 Example:
 ```js


### PR DESCRIPTION
While reading through the Zone API documentation I found a few small grammar issues in the introduction that slowed down my understanding. I went ahead and did a quick pass for grammar on the rest of the page as well.