### PR TITLE
Bugfix: Assertion failed: `workerId < _workers.size()`

### DIFF
--- a/src/zone/scheduler.h
+++ b/src/zone/scheduler.h
@@ -98,6 +98,7 @@ namespace zone {
             _workers.emplace_back(i, settings, workerSetupCallback, [this](WorkerId workerId) {
                 IdleWorkerNotificationCallback(workerId);
             });
+            _workers[i].Start();
 
             // All workers are idle initially.
             auto iter = _idleWorkers.emplace(_idleWorkers.end(), i);

--- a/src/zone/worker.cpp
+++ b/src/zone/worker.cpp
@@ -48,6 +48,9 @@ struct Worker::Impl {
 
     /// <summary> A callback function that is called when worker becomes idle. </summary>
     std::function<void(WorkerId)> idleNotificationCallback;
+
+    /// <summary> The zone settings for the current worker. </summary>
+    const settings::ZoneSettings* settings;
 };
 
 Worker::Worker(WorkerId id,
@@ -59,7 +62,7 @@ Worker::Worker(WorkerId id,
     _impl->id = id;
     _impl->setupCallback = std::move(setupCallback);
     _impl->idleNotificationCallback = std::move(idleNotificationCallback);
-    _impl->workerThread = std::thread(&Worker::WorkerThreadFunc, this, settings);
+    _impl->settings = &settings;
 }
 
 Worker::~Worker() {
@@ -77,6 +80,10 @@ Worker::~Worker() {
 
 Worker::Worker(Worker&&) = default;
 Worker& Worker::operator=(Worker&&) = default;
+
+void Worker::Start() {
+    _impl->workerThread = std::thread(&Worker::WorkerThreadFunc, this, *_impl->settings);
+}
 
 void Worker::Schedule(std::shared_ptr<Task> task) {
     NAPA_ASSERT(task != nullptr, "Task should not be null");

--- a/src/zone/worker.h
+++ b/src/zone/worker.h
@@ -42,6 +42,9 @@ namespace zone {
         Worker(Worker&&);
         Worker& operator=(Worker&&);
 
+        /// <summary> Start the underlying worker thread. </summary>
+        void Start();
+
         /// <summary> Schedules a task on this worker. </summary>
         /// <param name="task"> Task to schedule. </param>
         /// <note> Same task instance may run on multiple workers, hence the use of shared_ptr. </node>


### PR DESCRIPTION
Issue: https://github.com/Microsoft/napajs/issues/94

This issue is caused by a race condition that the underlying worker thread may be being executed 
before the worker object put into the vector.