### PR TITLE
Update CI matrix for Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ matrix:
   # Disable the default build and use customized matrix only.
   - compiler: default
   include:
-  # Node 4.5.0          Linux (Precise)     G++5.4.1
+  # Node 6.x            Linux (Precise)     G++5.4.1
   - os: linux
     dist: precise
-    node_js: '4.5.0'
+    node_js: '6'
     compiler: g++-5
     addons:
       apt:
@@ -23,20 +23,7 @@ matrix:
         - cmake
     env:
     - COMPILER_OVERRIDE="CXX=g++-5 CC=gcc-5"
-  # Node LTS (6.x)      Linux (Trusty)      G++5.4.1
-  - os: linux
-    dist: trusty
-    node_js: '6'
-    compiler: g++-5
-    addons:
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - g++-5
-    env:
-    - COMPILER_OVERRIDE="CXX=g++-5 CC=gcc-5"
-  # Node LTS (6.x)      OS X (Yosemite)     AppleClang 6.1
+  # Node 6.x            OS X (Yosemite)     AppleClang 6.1
   - os: osx
     node_js: '6'
     osx_image: xcode6.4
@@ -50,13 +37,30 @@ matrix:
         sources:
         - ubuntu-toolchain-r-test
         packages:
-        - g++-6
+        - g++-5
     env:
-    - COMPILER_OVERRIDE="CXX=g++-6 CC=gcc-6"
+    - COMPILER_OVERRIDE="CXX=g++-5 CC=gcc-5"
   # Node LTS (8.x)      OS X (El Capitan)   AppleClang 7.3
   - os: osx
     node_js: '8'
     osx_image: xcode7.3
+  # Node Stable (9.x)   Linux (Trusty)      G++6.3.0
+  - os: linux
+    dist: trusty
+    node_js: '9'
+    compiler: g++-6
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-6
+    env:
+    - COMPILER_OVERRIDE="CXX=g++-6 CC=gcc-6"
+  # Node Stable (9.x)   macOS (Sierra)      AppleClang 8.1
+  - os: osx
+    node_js: '9'
+    osx_image: xcode8.3
 
 before_install:
 - |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,13 +2,13 @@ environment:
   matrix:
     # Windows Server 2012 R2       Visual C++ Build Tools 2015
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      nodejs_version: 4.5.0
+      nodejs_version: 6
     # Windows Server 2012 R2       Visual C++ Build Tools 2015
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      nodejs_version: LTS
+      nodejs_version: 8
     # Windows Server 2016          Visual C++ Build Tools 2017
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      nodejs_version: Stable
+      nodejs_version: 9
 
 platform:
 - x64


### PR DESCRIPTION
Since Node.js released v9.0.0 and shifted LTS from 6.x to 8.x, we should update our CI matrix Node.js version from [4,6,8] to [6,8,9].