### PR TITLE
Fix build warning: ISO C++ forbids converting a string constant to ‘char*’

### DIFF
--- a/inc/napa/capi.h
+++ b/inc/napa/capi.h
@@ -88,7 +88,7 @@ EXTERN_C NAPA_API napa_result_code napa_initialize(napa_string_ref settings);
 /// <param name="argv"> The arguments. </param>
 EXTERN_C NAPA_API napa_result_code napa_initialize_from_console(
     int argc,
-    char* argv[]);
+    const char* argv[]);
 
 /// <summary> Invokes napa shutdown steps. All non released zones will be destroyed. </summary>
 EXTERN_C NAPA_API napa_result_code napa_shutdown();

--- a/inc/napa/zone.h
+++ b/inc/napa/zone.h
@@ -16,7 +16,7 @@ namespace napa {
     }
 
     /// <summary> Initialize napa using console provided arguments. </summary>
-    inline ResultCode InitializeFromConsole(int argc, char* argv[]) {
+    inline ResultCode InitializeFromConsole(int argc, const char* argv[]) {
         return napa_initialize_from_console(argc, argv);
     }
 

--- a/src/api/capi.cpp
+++ b/src/api/capi.cpp
@@ -184,7 +184,7 @@ napa_result_code napa_initialize(napa_string_ref settings) {
     return napa_initialize_common();
 }
 
-napa_result_code napa_initialize_from_console(int argc, char* argv[]) {
+napa_result_code napa_initialize_from_console(int argc, const char* argv[]) {
     NAPA_ASSERT(!_initialized, "Napa platform was already initialized");
 
     if (!napa::settings::ParseFromConsole(argc, argv, _platformSettings)) {

--- a/src/settings/settings-parser.h
+++ b/src/settings/settings-parser.h
@@ -58,7 +58,7 @@ namespace settings {
     /// </param>
     /// <returns> True if parsing succeeded, false otherwise. </returns>
     template <typename SettingsType>
-    bool ParseFromConsole(int argc, char* argv[], SettingsType& settings) {
+    bool ParseFromConsole(int argc, const char* argv[], SettingsType& settings) {
         std::vector<std::string> args;
 
         // Skip first parameter (program name)

--- a/unittest/settings/parser-tests.cpp
+++ b/unittest/settings/parser-tests.cpp
@@ -14,7 +14,7 @@ TEST_CASE("Parsing nothing doesn't fail", "[settings-parser]") {
 
     REQUIRE(settings::ParseFromString("", settings));
 
-    std::vector<char*> args = { "dummy.exe" };
+    std::vector<const char*> args = { "dummy.exe" };
     REQUIRE(settings::ParseFromConsole(static_cast<int>(args.size()), args.data(), settings));
 }
 
@@ -30,7 +30,7 @@ TEST_CASE("Parsing from console", "[settings-parser]") {
     settings::PlatformSettings settings;
     settings.loggingProvider = "";
 
-    std::vector<char*> args = { "dummy.exe", "--loggingProvider", "myProvider" };
+    std::vector<const char*> args = { "dummy.exe", "--loggingProvider", "myProvider" };
 
     REQUIRE(settings::ParseFromConsole(static_cast<int>(args.size()), args.data(), settings));
     REQUIRE(settings.loggingProvider == "myProvider");


### PR DESCRIPTION
  **This change has modification on napa's C API.**