### PR TITLE
Throw exception when node version is not supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
   # Node LTS (8.x)      Linux (Trusty)      G++6.3.0
   - os: linux
     dist: trusty
-    node_js: '8'
+    node_js: '8.4.0'
     compiler: g++-6
     addons:
       apt:
@@ -42,7 +42,7 @@ matrix:
     - COMPILER_OVERRIDE="CXX=g++-5 CC=gcc-5"
   # Node LTS (8.x)      OS X (El Capitan)   AppleClang 7.3
   - os: osx
-    node_js: '8'
+    node_js: '8.4.0'
     osx_image: xcode7.3
   # Node Stable (9.x)   Linux (Trusty)      G++6.3.0
   - os: linux
@@ -61,6 +61,16 @@ matrix:
   - os: osx
     node_js: '9'
     osx_image: xcode8.3
+  # There is a compatibility issue on Node v8.5.0 and above.
+  # So we fix the version to 8.4.0 on the build for 8.x, and
+  # allow failure for 9.x
+  #
+  # https://github.com/Microsoft/napajs/issues/96
+  # https://github.com/nodejs/node/issues/16658
+  #
+  # This should be removed once the issue resolved.
+  allow_failures:
+  - node_js: '9'
 
 before_install:
 - |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,22 @@ environment:
       nodejs_version: 6
     # Windows Server 2012 R2       Visual C++ Build Tools 2015
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      nodejs_version: 8
+      nodejs_version: 8.4.0
     # Windows Server 2016          Visual C++ Build Tools 2017
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       nodejs_version: 9
+
+# There is a compatibility issue on Node v8.5.0 and above.
+# So we fix the version to 8.4.0 on the build for 8.x, and
+# allow failure for 9.x
+#
+# https://github.com/Microsoft/napajs/issues/96
+# https://github.com/nodejs/node/issues/16658
+#
+# This should be removed once the issue resolved.
+matrix:
+  allow_failures:
+    - nodejs_version: 9
 
 platform:
 - x64

--- a/lib/binding.js
+++ b/lib/binding.js
@@ -1,19 +1,29 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-if (typeof __in_napa === 'undefined') {
+function failCheck(messages) {
+    messages.forEach(function(message) {
+        console.log('\x1b[1m\x1b[33m', message, '\x1b[0m');
+    });
+    throw new Error(messages.join(' '));
+}
+
+function checkNodeVersion() {
     if (process.version > 'v8.4.0' || process.version.indexOf('.') > 2) {
-        console.log('\x1b[1m\x1b[33m', 'Thanks for using Napa.js.', '\x1b[0m');
-        console.log('\x1b[1m\x1b[33m', 'There is a compatibility issue on Node v8.5.0 and above.', '\x1b[0m');
-        console.log('\x1b[1m\x1b[33m', 'We are working with Node.js team on a fix in newer Node versions.', '\x1b[0m');
-        console.log('\x1b[1m\x1b[33m', 'Please use Node with version v8.4.0 or lower.', '\x1b[0m');
-        process.exit();
+        failCheck([
+            'Thanks for using Napa.js.',
+            'There is a compatibility issue on Node v8.5.0 and above.',
+            'We are working with Node.js team on a fix in newer Node versions.',
+            'Please use Node with version v8.4.0 or lower.'
+        ]);
     }
     else if (process.version < 'v4.5') {
-        console.log('\x1b[1m\x1b[33m', 'Napa.js is not supported on Node version lower than v4.5', '\x1b[0m');
-        process.exit();
+        failCheck(['Napa.js is not supported on Node version lower than v4.5']);
     }
+}
 
+if (typeof __in_napa === 'undefined') {
+    checkNodeVersion();
     module.exports = require('../bin/napa-binding');
 } else {
     module.exports = process.binding('napa-binding');


### PR DESCRIPTION
* For node <4.5 and >=8.5.0 (https://github.com/Microsoft/napajs/issues/96) Napa.js is not running.
* The previous behavior uses process.exit() to quit the running process. This will break some automation scripts that depends on error code. Now an exception will be thrown.
* CI matrix also updated to ignore errors on node v9.x