### PR TITLE
dll::ThisLineLocation(): Remove UNC prefix '\\?\' if it presents

### DIFF
--- a/src/platform/dll.cpp
+++ b/src/platform/dll.cpp
@@ -72,6 +72,18 @@ std::string ThisLineLocation() {
     if (len == 0) {
         return "";
     }
+
+    // Currently we do not fully support UNC prefix in Napa.js.
+    //
+    // The following is a workaround to fix inconsistency of __dirname and __filename
+    // between Napa.js and Node.js
+    //
+    // https://github.com/Microsoft/napajs/issues/131
+    // Should remove this code when fixing Issue #131.
+    if (len > 4 && path[0] == '\\' && path[1] == '\\' && path[2] == '?' && path[3] == '\\') {
+        return path + 4;
+    }
+
     return path;
 #endif
 }

--- a/src/platform/dll.cpp
+++ b/src/platform/dll.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 #include <platform/dll.h>
+#include <platform/filesystem.h>
 #include <platform/platform.h>
 
 #ifdef SUPPORT_POSIX
@@ -80,7 +81,7 @@ std::string ThisLineLocation() {
     //
     // https://github.com/Microsoft/napajs/issues/131
     // Should remove this code when fixing Issue #131.
-    if (len > 4 && path[0] == '\\' && path[1] == '\\' && path[2] == '?' && path[3] == '\\') {
+    if (len > 4 && filesystem::Path(path).HasUncPrefix()) {
         return path + 4;
     }
 


### PR DESCRIPTION
This is a workaround to fix inconsistency of __dirname and __filename between Napa.js and Node.js.

The root cause is, Napajs does not fully support Windows UNC prefix yet. #131 is created to track
this issue.