### PR TITLE
[CI matrix] Revert node version for LTS/current to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
   # Node LTS (8.x)      Linux (Trusty)      G++6.3.0
   - os: linux
     dist: trusty
-    node_js: '8.4.0'
+    node_js: '8'
     compiler: g++-6
     addons:
       apt:
@@ -42,7 +42,7 @@ matrix:
     - COMPILER_OVERRIDE="CXX=g++-5 CC=gcc-5"
   # Node LTS (8.x)      OS X (El Capitan)   AppleClang 7.3
   - os: osx
-    node_js: '8.4.0'
+    node_js: '8'
     osx_image: xcode7.3
   # Node Stable (9.x)   Linux (Trusty)      G++6.3.0
   - os: linux
@@ -61,16 +61,6 @@ matrix:
   - os: osx
     node_js: '9'
     osx_image: xcode8.3
-  # There is a compatibility issue on Node v8.5.0 and above.
-  # So we fix the version to 8.4.0 on the build for 8.x, and
-  # allow failure for 9.x
-  #
-  # https://github.com/Microsoft/napajs/issues/96
-  # https://github.com/nodejs/node/issues/16658
-  #
-  # This should be removed once the issue resolved.
-  allow_failures:
-  - node_js: '9'
 
 before_install:
 - |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,22 +5,10 @@ environment:
       nodejs_version: 6
     # Windows Server 2012 R2       Visual C++ Build Tools 2015
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      nodejs_version: 8.4.0
+      nodejs_version: 8
     # Windows Server 2016          Visual C++ Build Tools 2017
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       nodejs_version: 9
-
-# There is a compatibility issue on Node v8.5.0 and above.
-# So we fix the version to 8.4.0 on the build for 8.x, and
-# allow failure for 9.x
-#
-# https://github.com/Microsoft/napajs/issues/96
-# https://github.com/nodejs/node/issues/16658
-#
-# This should be removed once the issue resolved.
-matrix:
-  allow_failures:
-    - nodejs_version: 9
 
 platform:
 - x64


### PR DESCRIPTION
Previous change https://github.com/Microsoft/napajs/commit/848b3713b1cb9ab67e26760f632b9db358436192 fails Napa.js on Node > 8.4.0 due to issue https://github.com/Microsoft/napajs/issues/96, so we also updated the corresponding Node version in CI matrix:
  - Node 8.x: Fixed to 8.4.0
  - Node 9.x: Current (Latest Release), Allow failure

Now we have a workaround in https://github.com/Microsoft/napajs/commit/0a22b5725d8156ce584e141e585ed956ed86eeb7 and it's time to revert the CI matrix:
  - Node 8.x: LTS (Latest Release)
  - Node 9.0: Current (Latest Release)