### PR TITLE
Fix hanging promise when callback from Napa to Node

### DIFF
--- a/test/memory-test.ts
+++ b/test/memory-test.ts
@@ -6,7 +6,6 @@ import * as assert from 'assert';
 import * as path from 'path';
 
 describe('napajs/memory', function() {
-    this.timeout(0);
     let napaZone = napa.zone.create('zone5');
 
     describe('Handle', () => {

--- a/test/module-test.ts
+++ b/test/module-test.ts
@@ -8,7 +8,6 @@ import * as path from "path";
 type Zone = napa.zone.Zone;
 
 describe('napajs/module', function () {
-    this.timeout(0);
     let napaZone = napa.zone.create('module-tests-zone', { workers: 1 });
 
     describe('load', function () {

--- a/test/store-test.ts
+++ b/test/store-test.ts
@@ -6,8 +6,6 @@ import * as assert from 'assert';
 import * as path from 'path';
 
 describe('napajs/store', function () {
-    this.timeout(0);
-
     let napaZone = napa.zone.create('zone6');
     let store1 = napa.store.create('store1');
     it('@node: store.create - succeed', () => {

--- a/test/zone-test.ts
+++ b/test/zone-test.ts
@@ -18,10 +18,6 @@ function shouldFail<T>(func: () => Promise<T>) {
 }
 
 describe('napajs/zone', function () {
-    // disable timeouts. 
-    // promise.then is always fired after mocha test timeout.
-    this.timeout(0);
-
     let napaZone1: Zone = napa.zone.create('napa-zone1');
     let napaZone2: Zone = napa.zone.create('napa-zone2');
     let napaLibPath: string = path.resolve(__dirname, '../lib');
@@ -32,11 +28,12 @@ describe('napajs/zone', function () {
             assert.strictEqual(napaZone1.id, 'napa-zone1');
         });
 
+        // This case may be slow as the first hit of napa zone execute API, so we clear timeout.
         it('@napa: default settings', async () => {
             // Zone should be destroyed when going out of scope.
             let result = await napaZone1.execute(`${napaLibPath}/zone`, 'create', ['new-zone']);
             assert.equal(result.value.id, "new-zone");
-        });
+        }).timeout(0);
 
         it('@node: zone id already exists', () => {
             assert.throws(() => { napa.zone.create('napa-zone1'); });


### PR DESCRIPTION
This change apply @tswaters 's patch on APIs that needs to be called back to Node event loop.
The issue was discussed in [https://github.com/audreyt/node-webworker-threads/issues/123#issuecomment-254019552](https://github.com/audreyt/node-webworker-threads/issues/123#issuecomment-254019552)

Verified this change fixes #27, #32, and #139.