### PR TITLE
fix macro LOG when NAPA_LOG_DISABLED is set

### DIFF
--- a/inc/napa/log.h
+++ b/inc/napa/log.h
@@ -8,8 +8,6 @@
 
 #include <stdarg.h>
 
-template <typename... Types> inline void ignore(Types&&...) {}
-
 /// <summary> The maximum string length of a single log call. Anything over will be truncated. </summary>
 const size_t LOG_MAX_SIZE = 512;
 
@@ -43,7 +41,8 @@ inline void LogFormattedMessage(
 
 #else
 
-#define LOG(section, level, traceId, format, ...) ignore(section, level, traceId, format, ##__VA_ARGS__)
+// Do nothing without generating any "unreferenced variable" warnings.
+template <typename... Types> inline void LOG(Types&&...) {}
 
 #endif
 

--- a/inc/napa/log.h
+++ b/inc/napa/log.h
@@ -43,12 +43,7 @@ inline void LogFormattedMessage(
 
 #else
 
-#define LOG(section, level, traceId, format, ...) \
-    UNUSED(section);                              \
-    UNUSED(level);                                \
-    UNUSED(traceId);                              \
-    UNUSED(format);                               \
-    UNUSED(__VA_ARGS__);
+#define LOG(section, level, traceId, format, ...) UNUSED(section, level, traceId, format, ##__VA_ARGS__)
 
 #endif
 

--- a/inc/napa/log.h
+++ b/inc/napa/log.h
@@ -8,7 +8,7 @@
 
 #include <stdarg.h>
 
-#define UNUSED(var) (void)(var)
+#define UNUSED(...) (void)(0, ##__VA_ARGS__)
 
 /// <summary> The maximum string length of a single log call. Anything over will be truncated. </summary>
 const size_t LOG_MAX_SIZE = 512;
@@ -43,7 +43,7 @@ inline void LogFormattedMessage(
 
 #else
 
-#define LOG(section, level, traceId, format, ...) UNUSED(section, level, traceId, format, ##__VA_ARGS__)
+#define LOG(section, level, traceId, format, ...) UNUSED(section, level, traceId, format, UNUSED(__VA_ARGS__))
 
 #endif
 

--- a/inc/napa/log.h
+++ b/inc/napa/log.h
@@ -8,7 +8,7 @@
 
 #include <stdarg.h>
 
-#define UNUSED(...) (void)(0, ##__VA_ARGS__)
+template <typename... Types> inline void ignore(Types&&...) {}
 
 /// <summary> The maximum string length of a single log call. Anything over will be truncated. </summary>
 const size_t LOG_MAX_SIZE = 512;
@@ -43,7 +43,7 @@ inline void LogFormattedMessage(
 
 #else
 
-#define LOG(section, level, traceId, format, ...) UNUSED(section, level, traceId, format, UNUSED(__VA_ARGS__))
+#define LOG(section, level, traceId, format, ...) ignore(section, level, traceId, format, ##__VA_ARGS__)
 
 #endif
 


### PR DESCRIPTION
Fix fix macro `LOG` when `NAPA_LOG_DISABLED` is set.

- `UNUSED(arg)` will fail if `arg` is empty.
- The previous implementation expended to multiple statements, which may cause issue