### PR TITLE
Fix Node's version to 9.2.1 on CI build (Linux)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,13 @@ matrix:
     node_js: '8'
     osx_image: xcode7.3
   # Node Stable (9.x)   Linux (Trusty)      G++6.3.0
+  # 2017-12-18 : There is a new compability issue for Linux+Node9.3.0, which cases a crash on Napa.js.
+  #              The Node.js version is fixed to 9.2.1 to suppress this issue.
+  #              Should revert this commit when issue resolved.
+  #                                                                                        - fs-eire
   - os: linux
     dist: trusty
-    node_js: '9'
+    node_js: '9.2.1'
     compiler: g++-6
     addons:
       apt:


### PR DESCRIPTION
To unblock CI build from https://github.com/Microsoft/napajs/issues/162, I am doing this temporary change.