### PR TITLE
Allow both .js and .ts files in /lib/core

### DIFF
--- a/lib/core/.gitignore
+++ b/lib/core/.gitignore
@@ -1,0 +1,9 @@
+# Ignore all .js files by default
+**/*.js
+
+# Specify all .js files to preserve explicitly
+!/assert.js
+!/events.js
+!/process.js
+!/tty.js
+!/util.js

--- a/lib/core/.npmignore
+++ b/lib/core/.npmignore
@@ -1,0 +1,1 @@
+# Keep this file so that npm can pick up correct files.


### PR DESCRIPTION
Both javascript and typescript files should be supported in folder /lib/core.

This is because sometimes we borrow javascript code from Node.js implementation, and sometimes we have our own typescript implementation.