### PR TITLE
Optimize macro napa debug

### DIFF
--- a/src/utils/debug.h
+++ b/src/utils/debug.h
@@ -6,7 +6,12 @@
 #include "napa/log.h"
 
 #if defined(DEBUG_NAPA)
-    #define NAPA_DEBUG(section, format, ...) LOG_DEBUG(section, format, ##__VA_ARGS__)
+
+#define NAPA_DEBUG(section, format, ...) LOG_DEBUG(section, format, ##__VA_ARGS__)
+
 #else
-    #define NAPA_DEBUG
+
+// Do nothing without generating any "unreferenced variable" warnings.
+template <typename... Types> inline void LOG_DEBUG(Types&&...) {}
+
 #endif

--- a/src/utils/debug.h
+++ b/src/utils/debug.h
@@ -12,6 +12,6 @@
 #else
 
 // Do nothing without generating any "unreferenced variable" warnings.
-template <typename... Types> inline void LOG_DEBUG(Types&&...) {}
+template <typename... Types> inline void NAPA_DEBUG(Types&&...) {}
 
 #endif

--- a/src/utils/debug.h
+++ b/src/utils/debug.h
@@ -12,6 +12,6 @@
 #else
 
 // Do nothing without generating any "unreferenced variable" warnings.
-template <typename... Types> inline void NAPA_DEBUG(Types&&...) {}
+#define NAPA_DEBUG(section, format, ...) ((void)0)
 
 #endif


### PR DESCRIPTION
The macro `NAPA_DEBUG` should be ignored completely when `DEBUG_NAPA` is not set.

[example] considering this code snippet:
```cpp
NAPA_DEBUG("test", "this is a string: %s", calculate_a_string(args).c_str());
```

Function `calculate_a_string` should not be called when `DEBUG_NAPA` is not set.
