### PR TITLE
Fix node version check

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -2,7 +2,9 @@
 // Licensed under the MIT license.
 
 function checkNodeVersion() {
-    if (process.version > 'v8.4.0' || process.version.indexOf('.') > 2) {
+    var semver = require('semver');
+    var currentNodeVersion = semver.coerce(process.version);
+    if (semver.gt(currentNodeVersion, 'v8.4.0')) {
         var log = require('npmlog');
         log.warn('napajs binding', 'Thanks for using Napa.js.');
         log.warn('napajs binding', 'There is a compatibility issue on Node v8.5.0 and above.');
@@ -10,7 +12,7 @@ function checkNodeVersion() {
         log.warn('napajs binding', 'We are working with Node.js team on a fix in newer Node versions.');
 
         require('v8').setFlagsFromString('--noincremental-marking');
-    } else if (process.version < 'v4.5') {
+    } else if (semver.lt(currentNodeVersion, 'v4.5')) {
         var errorMessage = 'Napa.js is not supported on Node version lower than v4.5';
         require('npmlog').error('napajs binding', errorMessage);
         throw new Error(errorMessage);

--- a/lib/binding.js
+++ b/lib/binding.js
@@ -12,7 +12,7 @@ function checkNodeVersion() {
         log.warn('napajs binding', 'We are working with Node.js team on a fix in newer Node versions.');
 
         require('v8').setFlagsFromString('--noincremental-marking');
-    } else if (semver.lt(currentNodeVersion, 'v4.5')) {
+    } else if (semver.lt(currentNodeVersion, 'v4.5.0')) {
         var errorMessage = 'Napa.js is not supported on Node version lower than v4.5';
         require('npmlog').error('napajs binding', errorMessage);
         throw new Error(errorMessage);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "node-pre-gyp": "^0.6.36",
-    "npmlog": "^4.1.2"
+    "npmlog": "^4.1.2",
+    "semver": "^5.5.0"
   },
   "devDependencies": {
     "node-pre-gyp-github": "^1.3.1",


### PR DESCRIPTION
This fixes the bug in node version check in file `lib/binding.js`

The behavior is to perform version check as string comparison, which causes `'v8.10.0' < 'v8.4.0' === true`.

fixes #200 