### PR TITLE
Fix build: add missing header file

### DIFF
--- a/src/platform/process.cpp
+++ b/src/platform/process.cpp
@@ -21,6 +21,7 @@
 
 #include <sys/stat.h>
 
+#include <functional>
 #include <memory>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Add the missing header file <functional> which causes build break on g++7.x

Fix #220