### PR TITLE
Fix crash on some linux environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   # Disable the default build and use customized matrix only.
   - compiler: default
   include:
-  # Node 6.x            Linux (Precise)     G++5.4.1
+  # Node 6.x                 Linux (Precise)          G++5.4.1
   - os: linux
     dist: precise
     node_js: '6'
@@ -23,46 +23,14 @@ matrix:
         - cmake
     env:
     - COMPILER_OVERRIDE="CXX=g++-5 CC=gcc-5"
-  # Node 6.x            OS X (Yosemite)     AppleClang 6.1
+  # Node 6.x                 OS X (Yosemite)          AppleClang 6.1
   - os: osx
     node_js: '6'
     osx_image: xcode6.4
-  # Node LTS (8.x)      Linux (Trusty)      G++6.3.0
-  # 2018-03-12 : There is a compability issue for the following platform/environment combination:
-  #                - Ubuntu 14.04
-  #                - Node 8.10.0 or later
-  #                - Node 9.3.0 or later
-  #              This issue causes a crash on Napa.js.
-  #              Issue detail: https://github.com/nodejs/node/issues/17817
-  #
-  #              Current available workaround:
-  #                1: Use Node 8.9.1 or 9.2.1
-  #                2: Use binaries (libnapa.so and napa-binding.node) that compiled in Ubuntu 16.04
-  #
-  #              Since travis-CI does not support Ubuntu 16.04 yet, we locked Node version to 8.9.1
-  #              for now.
-  #                                                                                        - fs-eire
+  # Node LTS (8.x)           Linux (Trusty)           G++6.3.0
   - os: linux
     dist: trusty
-    node_js: '8.9.1'
-    compiler: g++-6
-    addons:
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - g++-5
-    env:
-    - COMPILER_OVERRIDE="CXX=g++-5 CC=gcc-5"
-  # Node LTS (8.x)      OS X (El Capitan)   AppleClang 7.3
-  - os: osx
     node_js: '8'
-    osx_image: xcode7.3
-  # Node Stable (9.x)   Linux (Trusty)      G++6.3.0
-  # 2017-12-18 : Locked node.js version to 9.2.1. See above.
-  - os: linux
-    dist: trusty
-    node_js: '9.2.1'
     compiler: g++-6
     addons:
       apt:
@@ -72,10 +40,44 @@ matrix:
         - g++-6
     env:
     - COMPILER_OVERRIDE="CXX=g++-6 CC=gcc-6"
-  # Node Stable (9.x)   macOS (Sierra)      AppleClang 8.1
+  # Node LTS (8.x)           OS X (El Capitan)        AppleClang 7.3
+  - os: osx
+    node_js: '8'
+    osx_image: xcode7.3
+  # Node (9.x)               Linux (Trusty)           G++6.3.0
+  - os: linux
+    dist: trusty
+    node_js: '9'
+    compiler: g++-6
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-6
+    env:
+    - COMPILER_OVERRIDE="CXX=g++-6 CC=gcc-6"
+  # Node (9.x)               macOS (Sierra)           AppleClang 8.1
   - os: osx
     node_js: '9'
     osx_image: xcode8.3
+  # Node Current (10.x)       Linux (Trusty)          G++7.3.0
+  - os: linux
+    dist: trusty
+    node_js: '10'
+    compiler: g++-7
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-7
+    env:
+    - COMPILER_OVERRIDE="CXX=g++-7 CC=gcc-7"
+  # Node Current (10.x)       macOS (High Sierra)     AppleClang 9.1
+  - os: osx
+    node_js: '10'
+    osx_image: xcode9.3
 
 before_install:
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
   - os: osx
     node_js: '6'
     osx_image: xcode6.4
-  # Node LTS (8.x)           Linux (Trusty)           G++6.3.0
+  # Node LTS (8.x)           Linux (Trusty)           G++6.4.0
   - os: linux
     dist: trusty
     node_js: '8'
@@ -44,7 +44,7 @@ matrix:
   - os: osx
     node_js: '8'
     osx_image: xcode7.3
-  # Node (9.x)               Linux (Trusty)           G++6.3.0
+  # Node (9.x)               Linux (Trusty)           G++6.4.0
   - os: linux
     dist: trusty
     node_js: '9'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,26 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${PROJECT_SOURCE_DIR}/bin)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Set symbol visibility to hidden by default.
-# Napa shared library shares a few classes with napa-binding.node with different compile definition,
-# exposing the same symbols from both shared libraries may cause improper behaviors under gcc.
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set(CMAKE_VISIBILITY_INLINES_HIDDEN)
+if (NOT WIN32 AND NOT APPLE)
+    # Set symbol visibility to hidden by default.
+    # Napa shared library shares a few classes with napa-binding.node with different compile definition,
+    # exposing the same symbols from both shared libraries may cause improper behaviors under gcc.
+    set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+    set(CMAKE_VISIBILITY_INLINES_HIDDEN)
+
+    # Prevent symbol relocations internal to our wrapper library to be
+    # overwritten by the application.  And fail if there are missing
+    # symbols.
+    set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic -Wl,-Bsymbolic-functions")
+    set (CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-Bsymbolic -Wl,-Bsymbolic-functions")
+
+    # Fail if there are missing symbols, except when using Address Sanitizer
+    # since libasan symbols are supposed to be preloaded.
+    if (NOT ENABLE_ASAN)
+        set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs")
+        set (CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-z,defs")
+    endif ()
+endif ()
 
 # Build napa shared library.
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,18 +20,13 @@ if (NOT WIN32 AND NOT APPLE)
     set(CMAKE_CXX_VISIBILITY_PRESET hidden)
     set(CMAKE_VISIBILITY_INLINES_HIDDEN)
 
-    # Prevent symbol relocations internal to our wrapper library to be
-    # overwritten by the application.  And fail if there are missing
-    # symbols.
+    # Prevent symbol relocations internal to our wrapper library to be overwritten by the application.
     set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic -Wl,-Bsymbolic-functions")
     set (CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-Bsymbolic -Wl,-Bsymbolic-functions")
 
-    # Fail if there are missing symbols, except when using Address Sanitizer
-    # since libasan symbols are supposed to be preloaded.
-    if (NOT ENABLE_ASAN)
-        set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs")
-        set (CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-z,defs")
-    endif ()
+    # Mark object non-lazy runtime binding.
+    set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,now")
+    set (CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-z,now")
 endif ()
 
 # Build napa shared library.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,9 @@ environment:
     # Windows Server 2016          Visual C++ Build Tools 2017
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       nodejs_version: 9
+    # Windows Server 2016          Visual C++ Build Tools 2017
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      nodejs_version: 10
 
 platform:
 - x64


### PR DESCRIPTION
Update linker flags to prevent resolving incorrect symbols.

Fixes https://github.com/Microsoft/napajs/issues/162 and https://github.com/Microsoft/napajs/issues/225.
