### PR TITLE
Fix assert.ifError() usage in test

### DIFF
--- a/test/module-test.ts
+++ b/test/module-test.ts
@@ -177,7 +177,7 @@ describe('napajs/module', function () {
                     var fs = require('fs');
 
                     assert(fs.existsSync(__dirname + '/module/jsmodule.js'));
-                    assert.ifError(fs.existsSync(__dirname + '/non-existing-file.txt'));
+                    assert(!fs.existsSync(__dirname + '/non-existing-file.txt'));
                 });
             });
 


### PR DESCRIPTION
Node 10.x updated the function `assert.ifError()` so the old usage becomes no longer valid.

8.x: Throws value if value is truthy.
10.x: Throws value if value is not undefined or null. This is useful when testing the error argument in callbacks.

