### PR TITLE
remove --allow-native-syntax flag during worker initialization

### DIFF
--- a/src/zone/worker.cpp
+++ b/src/zone/worker.cpp
@@ -182,17 +182,9 @@ void Worker::WorkerThreadFunc(const settings::ZoneSettings& settings) {
         worker_argv[3] = workId.c_str();
         node::Environment* env = node::CreateEnvironment(isolate_data.get(), context, 4, worker_argv, 0, nullptr);
 
-        // Problem: it would impact relevant execution behavior because,
-        // 1. this logic couples with node bootstrapping logic,
-        // 2. the flag is a setting shared at process level.
-        // TODO : Re-evaluate the impact and figure out a solid solution at node.js / napa.js.
-        // node::LoadEnvironment need access to V8 intrinsics by flag '--allow_natives_syntax'.
-        // If the flag haven't been specified when launching node.js,
-        // it will be disabled again during node bootstrapping.
+        // TODO : Remove the lock here when process.dlopen becomes thread-safe.
         {
             std::lock_guard<std::mutex> lock(environment_loading_mutext);
-            const char allow_natives_syntax[] = "--allow_natives_syntax";
-            v8::V8::SetFlagsFromString(allow_natives_syntax, sizeof(allow_natives_syntax) - 1);
             node::LoadEnvironment(env);
         }
 


### PR DESCRIPTION
node doesn't need this flag since v10.2.0. Please refer to [20719](https://github.com/nodejs/node/pull/20719)