### PR TITLE
clean macro NAPA_API and NAPA_BINDING_API

### DIFF
--- a/inc/napa/exports.h
+++ b/inc/napa/exports.h
@@ -15,20 +15,12 @@
     static_assert(false, "Unknown dynamic link import/export semantics");
 #endif
 
-// API exported from napa.dll
+// API exported from napa.node
 #ifdef NAPA_EXPORTS
     #define NAPA_API DLL_EXPORT
 #else
     #define NAPA_API DLL_IMPORT
 #endif // NAPA_EXPORTS
-
-// API exported from napa-binding. (both napa.dll and napa-binding.node)
-#ifdef NAPA_BINDING_EXPORTS
-    #define NAPA_BINDING_API DLL_EXPORT
-#else
-    #define NAPA_BINDING_API DLL_IMPORT
-#endif // NAPA_BINDING_EXPORTS
-
 
 #ifdef __cplusplus
 #define EXTERN_C extern "C"

--- a/inc/napa/module/binding.h
+++ b/inc/napa/module/binding.h
@@ -17,7 +17,7 @@ namespace binding {
 
     /// <summary> Get 'module.exports' from napa binding. </summary>
     /// <returns> 'module.exports' object for napa binding (napajs/bin/napa-binding.node or napa.dll) </returns>
-    NAPA_BINDING_API v8::Local<v8::Object> GetBinding();
+    NAPA_API v8::Local<v8::Object> GetBinding();
 
     /// <summary> It calls 'module.require' from context of napa binding in C++. </summary> 
     /// <param name="moduleName"> Module name in node 'require' convention. </summary>

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -58,19 +58,19 @@ namespace store {
     /// <summary> Create a store by id. </summary>
     /// <param name="id"> Case-sensitive id. </summary>
     /// <returns> Newly created store, or nullptr if store associated with id already exists. </summary>
-    NAPA_API std::shared_ptr<Store> CreateStore(const char* id);
+    std::shared_ptr<Store> CreateStore(const char* id);
 
     /// <summary> Get or create a store by id. </summary>
     /// <param name="id"> Case-sensitive id. </summary>
     /// <returns> Existing or newly created store. Should never be nullptr. </summary>
-    NAPA_API std::shared_ptr<Store> GetOrCreateStore(const char* id);
+    std::shared_ptr<Store> GetOrCreateStore(const char* id);
 
     /// <summary> Get a store by id. </summary>
     /// <param name="id"> Case-sensitive id. </summary>
     /// <returns> Existing store or nullptr if not found. </summary>
-    NAPA_API std::shared_ptr<Store> GetStore(const char* id);
+    std::shared_ptr<Store> GetStore(const char* id);
 
     /// <summary> Get store count currently in use. </summary>
-    NAPA_API size_t GetStoreCount();
+    size_t GetStoreCount();
 }
 }

--- a/src/v8-extensions/v8-extensions.h
+++ b/src/v8-extensions/v8-extensions.h
@@ -11,7 +11,7 @@ namespace v8_extensions {
 
     class SerializedData;
 
-    class NAPA_API Utils {
+    class Utils {
         public:
         static std::shared_ptr<SerializedData>
         SerializeValue(v8::Isolate* isolate, v8::Local<v8::Value> value);

--- a/src/zone/node-zone.h
+++ b/src/zone/node-zone.h
@@ -26,7 +26,7 @@ namespace zone {
     class NodeZone : public Zone {
     public:
         /// <summary> Set delegate function for Broadcast and Execute on node zone. This is intended to be called from napa-binding.node. </summary>
-        static NAPA_API void Init(BroadcastDelegate broadcast, ExecuteDelegate execute);
+        static void Init(BroadcastDelegate broadcast, ExecuteDelegate execute);
 
         /// <summary> 
         ///    Retrieves an existing zone. 

--- a/src/zone/worker-context.h
+++ b/src/zone/worker-context.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <napa/exports.h>
-
 #include <array>
 
 namespace napa {
@@ -41,7 +39,7 @@ namespace zone {
     };
 
     /// <summary> Napa specific data stored at TLS. </summary>
-    class NAPA_API WorkerContext {
+    class WorkerContext {
     public:
 
         /// <summary> Initialize isolate data. </summary>


### PR DESCRIPTION
This change removed macro `NAPA_BINDING_API` since it is no longer useful in v0.4.x.
Some unnecessary declarations of macro `NAPA_API` are also removed.