### PR TITLE
Add cmake-js dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "semver": "^5.5.0"
   },
   "devDependencies": {
+    "cmake-js": "^3.7.3",
     "node-pre-gyp-github": "^1.3.1",
     "mocha": "^3.5.0",
     "typescript": "^2.4.2",


### PR DESCRIPTION
Hi Napajs team, 

I was installing Napajs from master and it failed as a result of a missing dependency, cmake-js. I've added it to the package.json, although I just put the most recent version; what would be the most appropriate minimum version requirement?

-Daniel