### PR TITLE
Add note about support in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ npm install napajs
 ```
 Other options can be found in [Build Napa.js](https://github.com/Microsoft/napajs/wiki/build-napa.js).
 
+**Note:** Napa.js requires Node versions >= v4.5.0 and < v8.5.0. We are working with the Node.js team on support in newer Node versions.
+
 ## Quick Start
 ```js
 var napa = require('napajs');


### PR DESCRIPTION
Napa.js currently only runs bug-free on Node versions >= v4.5.0 and <v8.5.0. This PR adds this information to the installation section so that users can more seamlessly start using Napa.js.